### PR TITLE
Fix various issues

### DIFF
--- a/config/search.json
+++ b/config/search.json
@@ -1,0 +1,11 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@type": "SearchListener",
+      "source": { "@id": "urn:solid-server:default:ResourceStore" },
+      "store": { "@id": "urn:solid-server:default:ResourceStore" },
+      "searchEndpoint": "http://example.org/my-search-endpoint"
+    }
+  ]
+}

--- a/file-search.json
+++ b/file-search.json
@@ -1,5 +1,8 @@
 {
-  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.0/components/context.jsonld"
+  ],
   "import": [
     "files-scs:config/app/main/default.json",
     "files-scs:config/app/init/default.json",
@@ -30,18 +33,13 @@
     "files-scs:config/util/logging/winston.json",
     "files-scs:config/util/representation-conversion/default.json",
     "files-scs:config/util/resource-locker/memory.json",
-    "files-scs-search:config/search.json",
-    "files-scs:config/util/variables/default.json"
+    "files-scs:config/util/variables/default.json",
+
+    "files-solid-search:config/search.json"
   ],
   "@graph": [
     {
-      "comment": "A single-pod server that stores its resources on disk."
-    },
-    {
-      "@type": "SearchListener",
-      "eventEmitter": { "@id": "urn:solid-server:default:ResourceStore" },
-      "store": { "@id": "urn:solid-server:default:ResourceStore" },
-      "searchEndpoint": "string"
+      "comment": "A single-pod server that stores its resources on disk and supports solid search."
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solid-search-community-server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solid-search-community-server",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
+    "start": "community-solid-server -c file-search.json",
     "build": "npm run build:ts && npm run build:components",
-    "build:components": "componentsjs-generator -s src -c dist/components -r knows-scs",
+    "build:components": "componentsjs-generator -s src -c dist/components -i .componentsignore -r solid-search --typeScopedContexts",
     "build:ts": "tsc"
   },
   "keywords": [
@@ -35,12 +36,12 @@
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server",
   "lsd:components": "dist/components/components.jsonld",
   "lsd:contexts": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.1/components/context.jsonld": "dist/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.0/components/context.jsonld": "dist/components/context.jsonld"
   },
   "lsd:importPaths": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.1/components/": "dist/components/",
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.1/config/": "config/",
-    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.1/dist/": "dist/"
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.0/components/": "dist/components/",
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.0/config/": "config/",
+    "https://linkedsoftwaredependencies.org/bundles/npm/solid-search-community-server/^0.0.0/dist/": "dist/"
   },
   "author": "Joep Meindertsma",
   "license": "MIT"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {getLoggerFor, ResourceStore, ResourceIdentifier} from '@solid/community-server';
+import type { EventEmitter } from 'events';
 import fetch from 'node-fetch';
 
 /**
@@ -7,8 +8,7 @@ import fetch from 'node-fetch';
  export class SearchListener {
   private readonly logger = getLoggerFor(this);
 
-  public constructor(source: NodeJS.EventEmitter, store: ResourceStore, searchEndpoint: string) {
-    // super();
+  public constructor(source: EventEmitter, store: ResourceStore, searchEndpoint: string) {
     // Every time a resource is changed, post to the Solid-Search instance
     source.on('changed', async(changed: ResourceIdentifier): Promise<void> => {
       const turtleStream = (await store.getRepresentation(changed, { type: { 'text/turtle': 1 } })).data;


### PR DESCRIPTION
This was easier when I was looking at it anyway then explaining it over text 😉 . After this the server can be started with `npx community-solid-server file-search.json` or `npm start` (and with the `-f` flag if you want to choose the data folder).

Summary of some things:
 * The build command was missing a reference to the `.componentsignore` file. Was also missing the flag that made it so you can write `"source"` in the config instead of `"SearchListener:_source"` (last one is not needed anymore once we switch to components.js 5.x). It was also using a prefix that didn't match the repo.
 * The EventEmitter import was missing.
 * Moved the components.js SearchListener definition to a separate file so it can be imported by other configurations.
 * Fixed file-search.json with correct imports and contexts.
 * Fixed components.js URLs in package.json (only the major version number is used, rest needs to be 0).